### PR TITLE
Apply a global exception handler for timebank

### DIFF
--- a/src/main/java/com/eum/bank/timeBank/controller/QRController.java
+++ b/src/main/java/com/eum/bank/timeBank/controller/QRController.java
@@ -7,6 +7,7 @@ import com.eum.bank.timeBank.controller.dto.response.QRResponseDto;
 import com.eum.bank.timeBank.service.QRService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -30,7 +31,7 @@ public class QRController {
     @PostMapping("/create")
     public ResponseEntity<APIResponse<QRResponseDto.QRCode>> createQRCode(
             @RequestHeader String userId,
-            @RequestBody QRRequestDto.BaseInfo dto
+            @RequestBody @Valid QRRequestDto.BaseInfo dto
     ) throws NoSuchAlgorithmException, InvalidKeyException {
 
         QRResponseDto.QRCode response = qrService.createQRCode(userId, dto.getAccountId());
@@ -41,7 +42,7 @@ public class QRController {
     @Operation(summary = "QR 스캔", description = "QR 코드에서 정보를 추출합니다.")
     @PostMapping("/scan")
     public ResponseEntity<APIResponse> scanQRCode(
-            @RequestBody QRRequestDto.QRCodeWithSenderInfo dto
+            @RequestBody @Valid QRRequestDto.QRCodeWithSenderInfo dto
     ) throws Exception {
 
         APIResponse response = qrService.scanQRCode(dto);

--- a/src/main/java/com/eum/bank/timeBank/controller/RemittanceController.java
+++ b/src/main/java/com/eum/bank/timeBank/controller/RemittanceController.java
@@ -14,6 +14,7 @@ import com.eum.bank.timeBank.service.ValidateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -38,7 +39,7 @@ public class RemittanceController {
     public ResponseEntity<APIResponse<TotalTransferHistoryResponseDTO.GetTotalTransferHistory>> QRRemittance(
             @Schema(description = "송금 요청", required = true)
             @RequestHeader String userId,
-            @RequestBody RemittanceRequestDto.QRRemittance dto
+            @RequestBody @Valid RemittanceRequestDto.QRRemittance dto
     ) throws NoSuchAlgorithmException, InvalidKeyException {
 
         boolean isValid = validateService.hmacRemittance(dto);
@@ -64,7 +65,7 @@ public class RemittanceController {
                     "\n보낸 거래만 보기: SEND, 받은 거래만 보기: RECEIVE  " +
                     "\n아무것도 입력하지 않으면 전체 리스트를 반환합니다.")
             @RequestParam(value = "type", required = false) TransactionType type,
-            @RequestBody RemittanceRequestDto.History dto
+            @RequestBody @Valid RemittanceRequestDto.History dto
     ) {
 
         return ResponseEntity.ok(accountTransferHistoryService.getUserHistory(type, dto));

--- a/src/main/java/com/eum/bank/timeBank/controller/dto/request/QRRequestDto.java
+++ b/src/main/java/com/eum/bank/timeBank/controller/dto/request/QRRequestDto.java
@@ -1,5 +1,6 @@
 package com.eum.bank.timeBank.controller.dto.request;
 
+import com.eum.bank.validator.ValidMessageOfHMAC;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
@@ -17,6 +18,7 @@ public class QRRequestDto {
 
         @Schema(description = "송금 받을 유저 정보", example = "<userId>%<accountId>%<createdAt>")
         @NotEmpty
+        @ValidMessageOfHMAC(field = 3)
         private String userInfo;
 
         @Schema(description = "송금 보낼 유저id", example = "123456789012")

--- a/src/main/java/com/eum/bank/timeBank/controller/dto/request/QRRequestDto.java
+++ b/src/main/java/com/eum/bank/timeBank/controller/dto/request/QRRequestDto.java
@@ -2,6 +2,7 @@ package com.eum.bank.timeBank.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 public class QRRequestDto {
@@ -20,7 +21,12 @@ public class QRRequestDto {
 
         @Schema(description = "송금 보낼 유저id", example = "123456789012")
         @NotEmpty
+        @Size(min = 12, max = 12, message = "계좌번호는 12자리이어야 합니다.")
         private String senderAccountId;
+
+        private void setSenderAccountId(String accountId){
+            this.senderAccountId = (accountId != null) ? accountId.trim() : null;
+        }
     }
 
     @Schema(description = "qr 생성을 위한 account 정보")
@@ -29,6 +35,11 @@ public class QRRequestDto {
 
         @Schema(description = "유저의 계좌 id", example = "123456789012")
         @NotEmpty
+        @Size(min = 12, max = 12, message = "계좌번호는 12자리이어야 합니다.")
         private String accountId;
+
+        private void setAccountId(String accountId){
+            this.accountId = (accountId != null) ? accountId.trim() : null;
+        }
     }
 }

--- a/src/main/java/com/eum/bank/timeBank/controller/dto/request/RemittanceRequestDto.java
+++ b/src/main/java/com/eum/bank/timeBank/controller/dto/request/RemittanceRequestDto.java
@@ -1,5 +1,6 @@
 package com.eum.bank.timeBank.controller.dto.request;
 
+import com.eum.bank.validator.ValidMessageOfHMAC;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class RemittanceRequestDto {
 
         @Schema(description = "원본 데이터", example = "<accountNumber>%<password>%<amount>%<receiverAccountNumber>")
         @NotEmpty
+        @ValidMessageOfHMAC(field = 4)
         private String remittanceInfo;
 
     }

--- a/src/main/java/com/eum/bank/timeBank/controller/dto/request/RemittanceRequestDto.java
+++ b/src/main/java/com/eum/bank/timeBank/controller/dto/request/RemittanceRequestDto.java
@@ -1,6 +1,5 @@
 package com.eum.bank.timeBank.controller.dto.request;
 
-import com.eum.bank.timeBank.domain.TransactionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
@@ -30,6 +29,10 @@ public class RemittanceRequestDto {
         @Schema(description = "계좌 id", example = "123456789012")
         @NotEmpty
         private String accountId;
+
+        private void setAccountId(String accountId){
+            this.accountId = (accountId != null) ? accountId.trim() : null;
+        }
 
     }
 

--- a/src/main/java/com/eum/bank/validator/MessageOfHMACValidator.java
+++ b/src/main/java/com/eum/bank/validator/MessageOfHMACValidator.java
@@ -1,0 +1,31 @@
+package com.eum.bank.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * @ValidMessageOfHMAC 의 Validator
+ * field의 수와 field를 나누는 %의 개수의 차이가 1인지 검증한다.
+ */
+public class MessageOfHMACValidator implements ConstraintValidator<ValidMessageOfHMAC, String> {
+
+    private int field;
+
+    @Override
+    public void initialize(ValidMessageOfHMAC constraintAnnotation) {
+        this.field = constraintAnnotation.field();
+    }
+
+    /**
+     * field의 수와 field를 나누는 %의 개수의 차이가 1인지 검증한다.
+     */
+    @Override
+    public boolean isValid(String message, ConstraintValidatorContext constraintValidatorContext) {
+        if(message == null || message.isEmpty()){
+            return false;
+        }
+
+        int count = message.length() - message.replace("%", "").length();
+        return count == field - 1;
+    }
+}

--- a/src/main/java/com/eum/bank/validator/ValidMessageOfHMAC.java
+++ b/src/main/java/com/eum/bank/validator/ValidMessageOfHMAC.java
@@ -1,0 +1,28 @@
+package com.eum.bank.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * HMAC 원본메시지 형식이 유효한지 검사하는 커스텀 어노테이션
+ * 원본메시지 내 % 개수(필드개수 - 1)를 확인한다.
+ */
+@Constraint(validatedBy = MessageOfHMACValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidMessageOfHMAC {
+    String message() default "요구하는 형식이 아닙니다. 다시 확인해주세요.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * 한 줄로 적힌 원본 메시지 내에 들어있는 필드의 개수.
+     * (예)"<userId>%<accountId>%<createdAt>" 와 같은 형식이라면, field 값은 3이다.
+     */
+    int field();
+}


### PR DESCRIPTION
Issue No. #76 

1. requestBody 에 @Valid 를 추가하여 GlobalExceptionHandler와 연결
2. accountId setter -> 이슈에 작성한 내용 달성.
3. HMAC 의 원본 메시지를 검사하는 custom valid annotation: @ValidMessageOfHMAC 

참고: requestHeader 는 @Valid 어노테이션 없이도 던져지는 예외가 GlobalExceptionHandler에 감지됨.